### PR TITLE
Dev geneva - create shortcut to file server on spawn

### DIFF
--- a/R/create-file-server-shortcut.R
+++ b/R/create-file-server-shortcut.R
@@ -1,0 +1,69 @@
+#' Create a shortcut to the file server directory
+#'
+#' Creates a Windows shortcut (.lnk file) or symbolic link (on Unix-like systems)
+#' to the project's file server directory.
+#'
+#' @param project_directory [character] Path to the local project directory. Required.
+#' @param file_server_path [character] Path to the file server location. Required.
+#'
+#' @return Invisibly returns TRUE if successful, FALSE otherwise.
+#'
+#' @importFrom tools file_path_sans_ext
+#'
+#' @keywords internal
+#'
+#' @examples
+#' \dontrun{
+#' create_file_server_shortcut(
+#'   project_directory = "~/my-project",
+#'   file_server_path = "//pedsis/peds/data/BBMC/prairie-outpost/my-project"
+#' )
+#' }
+
+create_file_server_shortcut <- function(project_directory, file_server_path) {
+
+  checkmate::assert_directory_exists(project_directory)
+  checkmate::assert_character(file_server_path, min.chars = 1, len = 1)
+
+  # Shortcut path in the project directory
+  shortcut_path <- file.path(project_directory, "File Server Data.lnk")
+
+  tryCatch({
+    # Check if running on Windows
+    if (.Platform$OS.type == "windows") {
+      # Use PowerShell to create shortcut
+      ps_command <- sprintf(
+        '$WshShell = New-Object -ComObject WScript.Shell; $Shortcut = $WshShell.CreateShortcut("%s"); $Shortcut.TargetPath = "%s"; $Shortcut.Save()',
+        gsub("/", "\\\\", shortcut_path),
+        gsub("/", "\\\\", file_server_path)
+      )
+
+      result <- system2("powershell", args = c("-Command", shQuote(ps_command, type = "cmd")),
+                        stdout = TRUE, stderr = TRUE)
+
+      if (file.exists(shortcut_path)) {
+        message("Created shortcut to file server at: ", shortcut_path)
+        return(invisible(TRUE))
+      } else {
+        warning("Shortcut creation may have failed. File not found at: ", shortcut_path)
+        return(invisible(FALSE))
+      }
+
+    } else {
+      # On non-Windows systems, create a symbolic link instead
+      symlink_path <- file.path(project_directory, "File Server Data")
+
+      if (file.exists(symlink_path)) {
+        warning("Symlink already exists at: ", symlink_path)
+        return(invisible(FALSE))
+      }
+
+      file.symlink(file_server_path, symlink_path)
+      message("Created symbolic link to file server at: ", symlink_path)
+      return(invisible(TRUE))
+    }
+  }, error = function(e) {
+    warning("Failed to create shortcut: ", e$message)
+    return(invisible(FALSE))
+  })
+}

--- a/R/create-file-server-shortcut.R
+++ b/R/create-file-server-shortcut.R
@@ -23,52 +23,82 @@ create_file_server_shortcut <- function(project_directory, file_server_path) {
   checkmate::assert_directory_exists(project_directory)
   checkmate::assert_character(file_server_path, min.chars = 1, len = 1)
 
-  # Shortcut path in the project directory
-  shortcut_path <- file.path(project_directory, "File Server Data.lnk")
-
   tryCatch({
     # Check if running on Windows
     if (.Platform$OS.type == "windows") {
 
+      # Delete any existing shortcut first
+      shortcut_path <- file.path(project_directory, "File Server Data.lnk")
+      if (file.exists(shortcut_path)) {
+        unlink(shortcut_path)
+      }
+
       # Create a temporary VBScript file
       vbs_script <- tempfile(fileext = ".vbs")
 
-      # Convert forward slashes to backslashes for Windows paths
-      shortcut_path_win <- normalizePath(shortcut_path, winslash = "\\", mustWork = FALSE)
+      # Normalize paths for Windows
+      # Use normalizePath for the shortcut location (must exist)
+      shortcut_path_win <- normalizePath(project_directory, winslash = "\\", mustWork = TRUE)
+      shortcut_path_win <- file.path(shortcut_path_win, "File Server Data.lnk")
+
+      # Convert forward slashes to backslashes for UNC path
       file_server_path_win <- gsub("/", "\\\\", file_server_path)
 
       # VBScript code to create shortcut
+      # Note: Using cat() to show the actual VBScript for debugging
       vbs_code <- sprintf(
-        'Set oWS = WScript.CreateObject("WScript.Shell")
-Set oLink = oWS.CreateShortcut("%s")
-oLink.TargetPath = "%s"
-oLink.Description = "Shortcut to project file server directory"
-oLink.Save',
+        'Set WshShell = WScript.CreateObject("WScript.Shell")
+Set oShellLink = WshShell.CreateShortcut("%s")
+oShellLink.TargetPath = "%s"
+oShellLink.WindowStyle = 1
+oShellLink.Description = "Project File Server Location"
+oShellLink.WorkingDirectory = "%s"
+oShellLink.Save
+',
         shortcut_path_win,
+        file_server_path_win,
         file_server_path_win
       )
 
-      # Write VBScript to temp file
-      writeLines(vbs_code, vbs_script)
+      # Write VBScript to temp file with UTF-8 encoding
+      con <- file(vbs_script, "w", encoding = "UTF-8")
+      writeLines(vbs_code, con)
+      close(con)
 
-      # Execute VBScript
+      message("Executing VBScript to create shortcut...")
+      message("Target: ", file_server_path_win)
+
+      # Execute VBScript with full path to cscript
       result <- system2(
         command = "cscript",
-        args = c("//nologo", shQuote(vbs_script)),
+        args = c("//nologo", normalizePath(vbs_script, winslash = "\\")),
         stdout = TRUE,
-        stderr = TRUE
+        stderr = TRUE,
+        wait = TRUE
       )
+
+      # Give it a moment
+      Sys.sleep(0.5)
 
       # Clean up VBScript file
       unlink(vbs_script)
 
       # Check if shortcut was created
       if (file.exists(shortcut_path)) {
-        message("Created shortcut to file server at: ", shortcut_path)
-        return(invisible(TRUE))
+        # Verify it's actually a shortcut file (should be binary and small)
+        file_info <- file.info(shortcut_path)
+        if (file_info$size > 0 && file_info$size < 10000) {
+          message("✓ Created shortcut to file server at: ", shortcut_path)
+          return(invisible(TRUE))
+        } else {
+          warning("Shortcut file was created but may be invalid (unusual size: ", file_info$size, " bytes)")
+          return(invisible(FALSE))
+        }
       } else {
-        warning("Shortcut creation may have failed. File not found at: ", shortcut_path)
-        warning("VBScript output: ", paste(result, collapse = "\n"))
+        warning("Shortcut creation failed. File not found at: ", shortcut_path)
+        if (length(result) > 0) {
+          warning("VBScript output: ", paste(result, collapse = "\n"))
+        }
         return(invisible(FALSE))
       }
 
@@ -77,12 +107,12 @@ oLink.Save',
       symlink_path <- file.path(project_directory, "File Server Data")
 
       if (file.exists(symlink_path)) {
-        warning("Symlink already exists at: ", symlink_path)
+        message("Symlink already exists at: ", symlink_path)
         return(invisible(FALSE))
       }
 
       file.symlink(file_server_path, symlink_path)
-      message("Created symbolic link to file server at: ", symlink_path)
+      message("✓ Created symbolic link to file server at: ", symlink_path)
       return(invisible(TRUE))
     }
   }, error = function(e) {

--- a/R/create-file-server-shortcut.R
+++ b/R/create-file-server-shortcut.R
@@ -8,8 +8,6 @@
 #'
 #' @return Invisibly returns TRUE if successful, FALSE otherwise.
 #'
-#' @importFrom tools file_path_sans_ext
-#'
 #' @keywords internal
 #'
 #' @examples
@@ -31,21 +29,46 @@ create_file_server_shortcut <- function(project_directory, file_server_path) {
   tryCatch({
     # Check if running on Windows
     if (.Platform$OS.type == "windows") {
-      # Use PowerShell to create shortcut
-      ps_command <- sprintf(
-        '$WshShell = New-Object -ComObject WScript.Shell; $Shortcut = $WshShell.CreateShortcut("%s"); $Shortcut.TargetPath = "%s"; $Shortcut.Save()',
-        gsub("/", "\\\\", shortcut_path),
-        gsub("/", "\\\\", file_server_path)
+
+      # Create a temporary VBScript file
+      vbs_script <- tempfile(fileext = ".vbs")
+
+      # Convert forward slashes to backslashes for Windows paths
+      shortcut_path_win <- normalizePath(shortcut_path, winslash = "\\", mustWork = FALSE)
+      file_server_path_win <- gsub("/", "\\\\", file_server_path)
+
+      # VBScript code to create shortcut
+      vbs_code <- sprintf(
+        'Set oWS = WScript.CreateObject("WScript.Shell")
+Set oLink = oWS.CreateShortcut("%s")
+oLink.TargetPath = "%s"
+oLink.Description = "Shortcut to project file server directory"
+oLink.Save',
+        shortcut_path_win,
+        file_server_path_win
       )
 
-      result <- system2("powershell", args = c("-Command", shQuote(ps_command, type = "cmd")),
-                        stdout = TRUE, stderr = TRUE)
+      # Write VBScript to temp file
+      writeLines(vbs_code, vbs_script)
 
+      # Execute VBScript
+      result <- system2(
+        command = "cscript",
+        args = c("//nologo", shQuote(vbs_script)),
+        stdout = TRUE,
+        stderr = TRUE
+      )
+
+      # Clean up VBScript file
+      unlink(vbs_script)
+
+      # Check if shortcut was created
       if (file.exists(shortcut_path)) {
         message("Created shortcut to file server at: ", shortcut_path)
         return(invisible(TRUE))
       } else {
         warning("Shortcut creation may have failed. File not found at: ", shortcut_path)
+        warning("VBScript output: ", paste(result, collapse = "\n"))
         return(invisible(FALSE))
       }
 

--- a/R/create-file-server-shortcut.R
+++ b/R/create-file-server-shortcut.R
@@ -5,6 +5,7 @@
 #'
 #' @param project_directory [character] Path to the local project directory. Required.
 #' @param file_server_path [character] Path to the file server location. Required.
+#' @param project_name [character] Name of the project (for shortcut naming). Required.
 #'
 #' @return Invisibly returns TRUE if successful, FALSE otherwise.
 #'
@@ -14,21 +15,26 @@
 #' \dontrun{
 #' create_file_server_shortcut(
 #'   project_directory = "~/my-project",
-#'   file_server_path = "//pedsis/peds/data/BBMC/prairie-outpost/my-project"
+#'   file_server_path = config_data$directory_file_server,
+#'   project_name = "my-project"
 #' )
 #' }
 
-create_file_server_shortcut <- function(project_directory, file_server_path) {
+create_file_server_shortcut <- function(project_directory, file_server_path, project_name) {
 
   checkmate::assert_directory_exists(project_directory)
   checkmate::assert_character(file_server_path, min.chars = 1, len = 1)
+  checkmate::assert_character(project_name, min.chars = 1, len = 1)
 
   tryCatch({
     # Check if running on Windows
     if (.Platform$OS.type == "windows") {
 
+      # Create shortcut name with project name
+      shortcut_name <- paste0("S-Drive-", project_name, ".lnk")
+      shortcut_path <- file.path(project_directory, shortcut_name)
+
       # Delete any existing shortcut first
-      shortcut_path <- file.path(project_directory, "File Server Data.lnk")
       if (file.exists(shortcut_path)) {
         unlink(shortcut_path)
       }
@@ -39,13 +45,12 @@ create_file_server_shortcut <- function(project_directory, file_server_path) {
       # Normalize paths for Windows
       # Use normalizePath for the shortcut location (must exist)
       shortcut_path_win <- normalizePath(project_directory, winslash = "\\", mustWork = TRUE)
-      shortcut_path_win <- file.path(shortcut_path_win, "File Server Data.lnk")
+      shortcut_path_win <- file.path(shortcut_path_win, shortcut_name)
 
       # Convert forward slashes to backslashes for UNC path
       file_server_path_win <- gsub("/", "\\\\", file_server_path)
 
       # VBScript code to create shortcut
-      # Note: Using cat() to show the actual VBScript for debugging
       vbs_code <- sprintf(
         'Set WshShell = WScript.CreateObject("WScript.Shell")
 Set oShellLink = WshShell.CreateShortcut("%s")
@@ -104,7 +109,8 @@ oShellLink.Save
 
     } else {
       # On non-Windows systems, create a symbolic link instead
-      symlink_path <- file.path(project_directory, "File Server Data")
+      symlink_name <- paste0("S-Drive-", project_name)
+      symlink_path <- file.path(project_directory, symlink_name)
 
       if (file.exists(symlink_path)) {
         message("Symlink already exists at: ", symlink_path)

--- a/R/start-project.R
+++ b/R/start-project.R
@@ -123,10 +123,21 @@ start_skeleton <- function(
     Sys.sleep(0.5)
 
     if (file.exists(config_path)) {
-      # Read the populated config to get the actual file server path
+      # Populate the config file to replace placeholders
+      populate_config(
+        path_in      = config_path,
+        project_name = project_name,
+        path_out     = config_path
+      )
+
+      # Small delay to ensure file is written
+      Sys.sleep(0.5)
+
+      # Now read the populated config
       config_data <- config::get(file = config_path)
 
       if (!is.null(config_data$directory_file_server)) {
+        message("Creating shortcut to: ", config_data$directory_file_server)
         create_file_server_shortcut(
           project_directory = destination_directory_full,
           file_server_path = config_data$directory_file_server

--- a/R/start-project.R
+++ b/R/start-project.R
@@ -119,9 +119,6 @@ start_skeleton <- function(
   if (offspring_type %in% c("cdw-skeleton-1", "neonatology-1")) {
     config_path <- file.path(destination_directory_full, "config.yml")
 
-    # Wait a moment to ensure file is written
-    Sys.sleep(0.5)
-
     if (file.exists(config_path)) {
       # Populate the config file to replace placeholders
       populate_config(
@@ -140,7 +137,8 @@ start_skeleton <- function(
         message("Creating shortcut to: ", config_data$directory_file_server)
         create_file_server_shortcut(
           project_directory = destination_directory_full,
-          file_server_path = config_data$directory_file_server
+          file_server_path = config_data$directory_file_server,
+          project_name = project_name
         )
       }
     }

--- a/R/start-project.R
+++ b/R/start-project.R
@@ -115,4 +115,23 @@ start_skeleton <- function(
   #   browser()
 
   purrr::walk2(.x=d$source, .y=d$destination, .f=~utils::download.file(url=.x, destfile=.y))
+
+  if (offspring_type %in% c("cdw-skeleton-1", "neonatology-1")) {
+    config_path <- file.path(destination_directory_full, "config.yml")
+
+    # Wait a moment to ensure file is written
+    Sys.sleep(0.5)
+
+    if (file.exists(config_path)) {
+      # Read the populated config to get the actual file server path
+      config_data <- config::get(file = config_path)
+
+      if (!is.null(config_data$directory_file_server)) {
+        create_file_server_shortcut(
+          project_directory = destination_directory_full,
+          file_server_path = config_data$directory_file_server
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION
Took a few tries, but I think I got this so it will automatically add a shortcut to the file server location. I don't know how to verify all of the package stuff is updated correctly, but when I pulled the dev version of the package with devtools and ran it on a new test repo, it worked. 

```
remotes::install_github(
  repo = "OuhscBbmc/pluripotent",
  ref = "dev-geneva",
  force = TRUE
)

```