### PR TITLE
swap to pak

### DIFF
--- a/.claude/commands/repo-work.md
+++ b/.claude/commands/repo-work.md
@@ -1,0 +1,47 @@
+# /repo-work
+
+Run this at the start of every Claude Code session in a CRDW project repo.
+
+## Steps
+
+1. Read `AGENTS.md` to load project rules, SQL style, and safety constraints.
+
+2. Check `documentation/github-issues.md`:
+   - If missing: run `python utility/export-repo-issues.py` and tell the user it was generated.
+   - If present: check the `Generated:` line at the top. If older than 7 days, ask the user if they want to refresh it before proceeding.
+
+3. Read `documentation/github-issues.md` in full. Summarize:
+   - The research question and study aim in one or two sentences
+   - The current open issues and any clear next steps
+   - What data types the study needs (diagnoses, medications, labs, encounters, etc.)
+
+4. Read `config.yml` to get `project_name` and `schema_name`.
+
+5. List what SQL scripts already exist in `manipulation/` so you don't regenerate them.
+
+6. If no SQL scripts exist yet beyond placeholders, propose which templates to populate
+   based on the study context — but do not run `populate-scripts.py` yet. Present the
+   proposal and wait for the user to confirm before running anything.
+
+7. Ask the user what they want to work on today.
+
+## Reminders
+
+- Do not run R scripts, flow.R, scribe-factory.R, or SQL against live databases without
+  explicit permission for that exact command.
+- Do not read or modify CSV files or spreadsheets without explicit permission.
+- ss- files require PI review before running.
+- Editing files is always safe. Running them requires a go-ahead.
+- Write a session log to `documentation/ai-sessions/yyyy-mm-dd short-title.md` at the end.
+
+## Script Naming
+
+Name SQL scripts with a two-digit sequence prefix that reflects dependency order:
+`01-patient.sql`, `02-dx.sql`, `03-medication-meditech.sql`, etc. The patient pool
+script is always `01`. This makes run order unambiguous without needing to read `flow.R`.
+
+## On tables_to_scribe
+
+Never add `ss-` files (ss_dx, ss_med, ss_clinic, etc.) to `tables_to_scribe` in
+`config.yml`. They are concept-set lookup inputs used by extraction scripts, not
+study output tables. Only final delivery tables belong in `tables_to_scribe`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A new project/repo called 'beasley-poc-1' can be generated in two ways:
 1. Run this single chunk of code, after updating the `project_name` and `destination_directory` arguments.
 
     ```r
-    remotes::install_github(repo="OuhscBbmc/pluripotent")
+    pak::pak("OuhscBbmc/pluripotent")
     pluripotent::start_cdw_skeleton_1(
       project_name            = "beasley-poc-1",
       destination_directory   = "~/bbmc/cdw"
@@ -26,9 +26,9 @@ A new project/repo called 'beasley-poc-1' can be generated in two ways:
 1. The [cdw-template-1](https://github.com/OuhscBbmc/cdw-template-1) repo provides a platform to jump-start consistent repos for CDW projects.  Once it's used as a [GitHub template](https://help.github.com/en/articles/creating-a-repository-from-a-template), the [`utility/spawn.R`](https://github.com/OuhscBbmc/cdw-template-1/blob/main/utility/spawn.R) file contains the following dynamic code that should run without modification.
 
     ```r
-    # Install remotes & pluripotent if not already installed.  pluripotent won't reinstall if it's already up-to-date.
-    if( !requireNamespace("remotes") ) utils::install.packages("remotes")
-    remotes::install_github("OuhscBbmc/pluripotent")
+    # Install pak & pluripotent if not already installed.  pluripotent won't reinstall if it's already up-to-date.
+    if( !requireNamespace("pak") ) utils::install.packages("pak")
+    pak::pak("OuhscBbmc/pluripotent")
 
     # Discover repo name & parent directory.
     project_name          <- basename(normalizePath(".."))
@@ -71,11 +71,11 @@ If you want to use this package for projects that aren't included in [inst/metad
 Installation and Documentation
 --------------------------------------
 
-The *development* version can be installed from [GitHub](https://github.com/OuhscBbmc/pluripotent) after installing the [remotes](https://CRAN.R-project.org/package=remotes) package.
+The *development* version can be installed from [GitHub](https://github.com/OuhscBbmc/pluripotent) after installing the [pak](https://CRAN.R-project.org/package=pak) package.
 
 ```r
-install.packages("pluripotent") # Run this line if the 'remotes' package isn't installed already.
-remotes::install_github(repo="OuhscBbmc/pluripotent")
+install.packages("pak") # Run this line if the 'pak' package isn't installed already.
+pak::pak("OuhscBbmc/pluripotent")
 ```
 
 The package can be uninstalled from your local machine with `remove.packages("pluripotent")`.


### PR DESCRIPTION
Moving from remotes to pak, because remotes overrides its own arguments to pull windows environment variables, so GITHUB_TOKEN is causing 401 errors when trying to install. Google sez remotes is old business anyway.